### PR TITLE
fixing undefined variable prefix, the rest of the script uses env

### DIFF
--- a/wordpress_ha/provisioning_sg.yml
+++ b/wordpress_ha/provisioning_sg.yml
@@ -104,4 +104,4 @@
           - proto: tcp
             from_port: 3306
             to_port: 3306
-            group_name: "{{ prefix }}_sg_web"
+            group_name: "{{ env }}_sg_web"


### PR DESCRIPTION
I've just tried to run  this and it gives me back the error:

fatal: [localhost] => One or more undefined variables: 'prefix' is undefined

I suppose you meant to call it as in the other task just env. 
