### PR TITLE
Fix for invalid private key saving

### DIFF
--- a/keypair.yml
+++ b/keypair.yml
@@ -10,11 +10,11 @@
       local_action:  
         module: ec2_key  
         region: "{{ region }}"
-        name: yan1
+        name: "{{ keyname }}"
 #        state: absent
       register: mykey
     - name: write to file
-      local_action: shell echo -e "{{ item.value.private_key }}" > ~/.ssh/"{{ keyname }}".pem && chmod 600 ~/.ssh/"{{ keyname }}".pem
+      local_action: shell echo -e "{{ item.value.private_key }}" > ~/.ssh/"{{ keyname }}".pem && chmod 600 ~/.ssh/"{{ keyname }}".pem && sed -i 's/^-e //g' ~/.ssh/"{{ keyname }}".pem
       with_dict: mykey
       when: item.value.private_key is defined
    

--- a/wordpress/provisioning.yml
+++ b/wordpress/provisioning.yml
@@ -20,7 +20,7 @@
       register: mykey  
     - name: write the private key to a file  
       tags: keypair  
-      local_action: shell echo -e "{{ item.value.private_key }}" > ~/.ssh/"{{ keyname }}".pem && chmod 600 ~/.ssh/"{{ keyname }}".pem      
+      local_action: shell echo -e "{{ item.value.private_key }}" > ~/.ssh/"{{ keyname }}".pem && chmod 600 ~/.ssh/"{{ keyname }}".pem && sed -i 's/^-e //g' ~/.ssh/"{{ keyname }}".pem      
       with_dict: mykey   
       when: item.value.private_key is defined     
 


### PR DESCRIPTION
This PR is for issue #5. The initial "-e " is removed from private key while saving it to local. Tested.
