### PR TITLE
added region to aws command to get vpc id

### DIFF
--- a/vpc_delete1.yml
+++ b/vpc_delete1.yml
@@ -7,7 +7,7 @@
   tasks:
     - name: get vpc id
       command: "aws ec2 describe-vpcs --filters Name=tag:Name,Values={{ name }}
-               --query 'Vpcs[0].VpcId' --output text"
+               --query 'Vpcs[0].VpcId' --output text --region {{ region }}"
       register: vpcid
 
     - debug: var=vpcid.stdout


### PR DESCRIPTION
The aws command executed through the command line for the  'get vpc id' task did not specify the region. If the default region of the machine executing the playbook was not 'ap-southeast-2', then the vpc could not be found to be deleted by the next task.

This change adds the --region option to the aws command and sets it to the region variable defined in the file.